### PR TITLE
add limit parameter to last()

### DIFF
--- a/pycvesearch/core.py
+++ b/pycvesearch/core.py
@@ -42,11 +42,11 @@ class CVESearch(object):
         data = self._http_get('cve', query=param)
         return data.json()
 
-    def last(self):
+    def last(self, param=None):
         """ last() returns a dict containing the last 30 CVEs including CAPEC,
             CWE and CPE expansions
         """
-        data = self._http_get('last')
+        data = self._http_get('last', query=param)
         return data.json()
 
     def dbinfo(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,6 +22,9 @@ class TestPyCVESearch(unittest.TestCase):
     def test_last(self):
         self.cve.last()
 
+    def test_last_50(self):
+        self.cve.last(50)
+
     def test_dbinfo(self):
         self.cve.dbinfo()
 


### PR DESCRIPTION
Hello,
I saw that there is a possibility to add a limit parameter in the cve-search web api, so I added that to your wrapper, in case you want to make it available to everyone.

from https://github.com/cve-search/cve-search/blob/master/web/api.py
```
{'r': '/api/last/','m': ['GET'], 'f': self.api_last},
{'r': '/api/last/<int:limit>', 'm': ['GET'], 'f': self.api_last},
```
Note: the public cve-search service disabled this feature, I tested it on a private instance.
