### PR TITLE
Fix python3 setup.py error with LC_ALL=C

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='Apache v2.0 License',
     packages=['pycvesearch'],
     description='A python wrapper around cve.circl.lu',
-    long_description=open('README.md', 'r').read(),
+    long_description=open('README.md', 'rb').read().decode('UTF-8'),
     keywords=['CVE', 'API', 'wrapper'],
     classifiers=[
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
```shell
File setup.py, line 15, in <module>
    long_description=open('README.md', 'r').read(),
File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1315: ordinal not in range(128)
```