### PR TITLE
fix base url value

### DIFF
--- a/pycvesearch/core.py
+++ b/pycvesearch/core.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 
 class CVESearch(object):
 
-    def __init__(self, base_url: str, proxies: MutableMapping[str, str]={}, timeout: Optional[int]=None):
+    def __init__(self, base_url: 'https://cve.circl.lu/', proxies: MutableMapping[str, str]={}, timeout: Optional[int]=None):
         self.base_url = base_url
         self.session = requests.Session()
         self.session.proxies = proxies


### PR DESCRIPTION
This is the current behavior : 
>>> from pycvesearch import CVESearch
>>> cve = CVESearch()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() missing 1 required positional argument: 'base_url'
>>> 
Otherwise please change the wiki to initialize as follow:
>>> cve = CVESearch('https://cve.circl.lu/')